### PR TITLE
Use HTTPS URLs for Maven repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Jzy3d, based on JOGL, enables Java applications to use OpenGL to make best usage
 
 ## Demos
 
-See demos in package <a href="https://github.com/jzy3d/jzy3d-bigviz/blob/master/src/test/java/org/jzy3d/demos/">org.jzy3d.demos</a>
+See demos in package [`org.jzy3d.demos`](src/main/java/org/jzy3d/demos)
 
 
 
@@ -157,8 +157,7 @@ public class DemoTableAnalysis {
 
 <img src="doc/images/table-batch-report.png"/>
 
-
-https://github.com/jzy3d/bigpicture/blob/master/src/test/java/org/jzy3d/analysis/table/DemoTableAnalysis.java
+[`DemoTableAnalysis.java`](src/main/java/org/jzy3d/demos/analysis/table/DemoTableAnalysis.java)
 
 
 ## Utilities

--- a/pom.xml
+++ b/pom.xml
@@ -39,18 +39,14 @@
 
 	<repositories>
 		<repository>
-			<id>Spark repository</id>
-			<url>http://www.sparkjava.com/nexus/content/repositories/spark/</url>
-		</repository>
-		<repository>
 			<id>jzy3d-snapshots</id>
 			<name>Jzy3d Snapshots</name>
-			<url>http://maven.jzy3d.org/snapshots</url>
+			<url>https://maven.jzy3d.org/snapshots</url>
 		</repository>
 		<repository>
 			<id>jzy3d-releases</id>
 			<name>Jzy3d Snapshots</name>
-			<url>http://maven.jzy3d.org/releases</url>
+			<url>https://maven.jzy3d.org/releases/</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml.releaseBackup
+++ b/pom.xml.releaseBackup
@@ -33,18 +33,14 @@
 
 	<repositories>
 		<repository>
-			<id>Spark repository</id>
-			<url>http://www.sparkjava.com/nexus/content/repositories/spark/</url>
-		</repository>
-		<repository>
 			<id>jzy3d-snapshots</id>
 			<name>Jzy3d Snapshots</name>
-			<url>http://www.jzy3d.org/maven/snapshots</url>
+			<url>https://maven.jzy3d.org/snapshots</url>
 		</repository>
 		<repository>
 			<id>jzy3d-releases</id>
 			<name>Jzy3d Snapshots</name>
-			<url>http://www.jzy3d.org/maven/releases</url>
+			<url>https://maven.jzy3d.org/releases/</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml.versionsBackup
+++ b/pom.xml.versionsBackup
@@ -33,18 +33,14 @@
 
 	<repositories>
 		<repository>
-			<id>Spark repository</id>
-			<url>http://www.sparkjava.com/nexus/content/repositories/spark/</url>
-		</repository>
-		<repository>
 			<id>jzy3d-snapshots</id>
 			<name>Jzy3d Snapshots</name>
-			<url>http://www.jzy3d.org/maven/snapshots</url>
+			<url>https://maven.jzy3d.org/snapshots</url>
 		</repository>
 		<repository>
 			<id>jzy3d-releases</id>
 			<name>Jzy3d Snapshots</name>
-			<url>http://www.jzy3d.org/maven/releases</url>
+			<url>https://maven.jzy3d.org/releases/</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Removed http://www.sparkjava.com/nexus/content/repositories/spark/ because that does not exist anymore.